### PR TITLE
Load Removal

### DIFF
--- a/LiveSplit/config.json
+++ b/LiveSplit/config.json
@@ -2,7 +2,7 @@
   "AutoStart": true,
   "AutoSplit": true,
   "AutoReset": true,
-  "LoadRemoval": true,
+  "Remove Loads": true,
 
   "Exit Outlands": true,
   "Dog Bed Skip": true,

--- a/LiveSplit/config.json
+++ b/LiveSplit/config.json
@@ -2,6 +2,7 @@
   "AutoStart": true,
   "AutoSplit": true,
   "AutoReset": true,
+  "LoadRemoval": true,
 
   "Exit Outlands": true,
   "Dog Bed Skip": true,

--- a/LiveSplit/index.js
+++ b/LiveSplit/index.js
@@ -3,7 +3,7 @@
     * By NERS
 */
 
-export default function(mod, { atlas, content, CosmosText, events, filters, game, logician, music, renderer, SAVE, sounds, text, typer, world })
+export default function(mod, { atlas, content, CosmosText, events, filters, game, logician, music, renderer, SAVE, sounds, text, typer, world, battler})
 {
     const socket = new WebSocket("ws://localhost:16834/livesplit");
     var prefs = {};
@@ -19,7 +19,8 @@ export default function(mod, { atlas, content, CosmosText, events, filters, game
         neutralTriggered = false,
         neutralTriggered2 = false,
         pacifistTriggered = false,
-        bullyTriggered = false;
+        bullyTriggered = false,
+        battleLoading = false;
 
     const statusText = new CosmosText(
     {
@@ -192,6 +193,10 @@ export default function(mod, { atlas, content, CosmosText, events, filters, game
                     bullyTriggered = true;
                 }
             }
+            if (prefs["LoadRemoval"] && !battleLoading && !battler.active && battler.SOUL.position.x == battler.buttons[0].position.add(8, 11).x && game.movement == false) {
+                battleLoading = true;
+                socket.send("pausegametime")
+            }
         }
     })
 
@@ -211,6 +216,23 @@ export default function(mod, { atlas, content, CosmosText, events, filters, game
                     split.triggered = true;
                 }
             })
+        }
+        if (socket.readyState == 1 && prefs["LoadRemoval"])
+            socket.send("pausegametime");
+    })
+
+    events.on("teleport", (origin, dest) => {
+       if (socket.readyState == 1 && prefs["LoadRemoval"]) {
+           socket.send("unpausegametime");
+       }
+    });
+
+    events.on("battle", () => {
+        if (battleLoading)
+        {
+            if (socket.readyState == 1)
+                socket.send("unpausegametime");
+            battleLoading = false;
         }
     })
 


### PR DESCRIPTION
Added load removal for both room transitions and loading lag into battle.

Note that battles start loading at the same time the soul starts moving into position so there isn't always loading lag to remove, and the battle load removal does not apply if the player has movement (e.g. closed Postcard during the encounter animation in a Glitched speedrun).